### PR TITLE
FCHL19 with periodic boundary conditions and revised OpenMP parallelization

### DIFF
--- a/src/qmllib/representations/facsf.f90
+++ b/src/qmllib/representations/facsf.f90
@@ -634,7 +634,7 @@ end subroutine fgenerate_acsf_and_gradients
 
 
 subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
-                          & Rs2, Rs3, Ts, eta2, eta3, zeta, rcut, acut, natoms, rep_size, &
+                          & Rs2, Rs3, Ts, eta2, eta3, zeta, rcut, acut, natoms, natoms_tot, rep_size, &
                           & two_body_decay, three_body_decay, three_body_weight, rep)
 
     use acsf_utils, only: decay, calc_angle, calc_cos_angle
@@ -652,7 +652,7 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
     double precision, intent(in) :: zeta
     double precision, intent(in) :: rcut
     double precision, intent(in) :: acut
-    integer, intent(in) :: natoms
+    integer, intent(in) :: natoms, natoms_tot
     integer, intent(in) :: rep_size
     double precision, intent(in) :: two_body_decay
     double precision, intent(in) :: three_body_decay
@@ -660,12 +660,14 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
 
     double precision, intent(out), dimension(natoms, rep_size) :: rep
 
+    integer:: two_body_rep_size
     integer :: i, j, k, l, n, m, o, p, q, s, z, nelements, nbasis2, nbasis3, nabasis
     integer, allocatable, dimension(:) :: element_types
     double precision :: rij, rik, angle, cos_1, cos_2, cos_3, invcut
     ! double precision :: angle_1, angle_2, angle_3
     double precision, allocatable, dimension(:) :: radial, angular, a, b, c
-    double precision, allocatable, dimension(:, :) :: distance_matrix, rdecay, rep3
+    double precision, allocatable, dimension(:, :) :: distance_matrix, rdecay
+    double precision, allocatable, dimension(:, :) :: rep_2body
 
     double precision :: mu, sigma, ksi3
 
@@ -683,36 +685,36 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
     ! number of element types
     nelements = size(elements)
     ! Allocate temporary
-    allocate(element_types(natoms))
+    allocate(element_types(natoms_tot))
 
     ! Store element index of every atom
-    ! !$OMP PARALLEL DO
-    do i = 1, natoms
+    !$OMP PARALLEL DO
+    do i = 1, natoms_tot
         do j = 1, nelements
-            if (nuclear_charges(i) .eq. elements(j)) then
+            if (nuclear_charges(modulo(i-1, natoms)+1) .eq. elements(j)) then
                 element_types(i) = j
                 continue
             endif
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
 
 
     ! Get distance matrix
     ! Allocate temporary
-    allocate(distance_matrix(natoms, natoms))
+    allocate(distance_matrix(natoms_tot, natoms_tot))
     distance_matrix = 0.0d0
 
 
-    !  !$OMP PARALLEL DO PRIVATE(rij)
-    do i = 1, natoms
-        do j = i+1, natoms
+    !$OMP PARALLEL DO PRIVATE(rij) COLLAPSE(1)
+    do i = 1, natoms_tot
+        do j = i+1, natoms_tot
             rij = norm2(coordinates(j,:) - coordinates(i,:))
             distance_matrix(i, j) = rij
             distance_matrix(j, i) = rij
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
 
     ! number of basis functions in the two body term
     nbasis2 = size(Rs2)
@@ -721,41 +723,45 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
     invcut = 1.0d0 / rcut
 
     ! pre-calculate the radial decay in the two body terms
-    rdecay = decay(distance_matrix, invcut, natoms)
+    rdecay = decay(distance_matrix, invcut, natoms_tot)
 
     ! Allocate temporary
     allocate(radial(nbasis2))
-
+    two_body_rep_size=nbasis2*nelements
+    allocate(rep_2body(natoms, two_body_rep_size))
+    rep=0.0d0
+    rep_2body=0.0d0
     radial = 0.0d0
-    ! !$OMP PARALLEL DO PRIVATE(n,m,rij,radial) REDUCTION(+:rep)
+    !$OMP PARALLEL DO PRIVATE(n,m,rij,radial,mu,sigma) COLLAPSE(1) REDUCTION(+:rep_2body) SCHEDULE(dynamic)
     do i = 1, natoms
-        ! index of the element of atom i
-        m = element_types(i)
-        do j = i + 1, natoms
+        do j = i + 1, natoms_tot
+            ! index of the element of atom i
+            m = element_types(i) ! moved incide j loop to enable COLLAPSE
             ! index of the element of atom j
             n = element_types(j)
             ! distance between atoms i and j
             rij = distance_matrix(i,j)
-            if (rij <= rcut) then
+            if (rij > rcut) cycle
+            ! two body term of the representation
+            mu    = log(rij / sqrt(1.0d0 + eta2  / rij**2))
+            sigma = sqrt(log(1.0d0 + eta2  / rij**2))
+            radial(:) = 0.0d0
 
-                ! two body term of the representation
-                mu    = log(rij / sqrt(1.0d0 + eta2  / rij**2))
-                sigma = sqrt(log(1.0d0 + eta2  / rij**2))
-                radial(:) = 0.0d0
-
-                do k = 1, nbasis2
-                   radial(k) = 1.0d0/(sigma* sqrt(2.0d0*pi) * Rs2(k)) * rdecay(i,j) &
+            do k = 1, nbasis2
+                radial(k) = 1.0d0/(sigma* sqrt(2.0d0*pi) * Rs2(k)) * rdecay(i,j) &
                               & * exp( - (log(Rs2(k)) - mu)**2 / (2.0d0 * sigma**2) ) / rij**two_body_decay
-                enddo
+            enddo
 
-                rep(i, (n-1)*nbasis2 + 1:n*nbasis2) = rep(i, (n-1)*nbasis2 + 1:n*nbasis2) + radial
-                rep(j, (m-1)*nbasis2 + 1:m*nbasis2) = rep(j, (m-1)*nbasis2 + 1:m*nbasis2) + radial
-            endif
+            rep_2body(i, (n-1)*nbasis2 + 1:n*nbasis2) = rep_2body(i, (n-1)*nbasis2 + 1:n*nbasis2) + radial
+            if (j<=natoms) rep_2body(j, (m-1)*nbasis2 + 1:m*nbasis2) = rep_2body(j, (m-1)*nbasis2 + 1:m*nbasis2) + radial
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
+
+    rep(:, 1:two_body_rep_size)=rep_2body(:, :)
 
     deallocate(radial)
+    deallocate(rep_2body)
 
     ! number of radial basis functions in the three body term
     nbasis3 = size(Rs3)
@@ -765,23 +771,20 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
     ! Inverse of the three body cutoff
     invcut = 1.0d0 / acut
     ! pre-calculate the radial decay in the three body terms
-    rdecay = decay(distance_matrix, invcut, natoms)
+    rdecay = decay(distance_matrix, invcut, natoms_tot)
 
     ! Allocate temporary
-    allocate(rep3(natoms,rep_size))
     allocate(a(3))
     allocate(b(3))
     allocate(c(3))
     allocate(radial(nbasis3))
     allocate(angular(nabasis))
 
-    rep3 = 0.0d0
-
     ! This could probably be done more efficiently if it's a bottleneck
     ! Also the order is a bit wobbly compared to the tensorflow implementation
-    ! !$OMP PARALLEL DO PRIVATE(rij, n, rik, m, a, b, c, angle, radial, angular, &
-    ! !$OMP cos_1, cos_2, cos_3, mu, sigma, o, ksi3, &
-    ! !$OMP p, q, s, z) REDUCTION(+:rep3) COLLAPSE(2) SCHEDULE(dynamic)
+    !$OMP PARALLEL DO PRIVATE(rij, n, rik, m, a, b, c, angle, radial, angular, &
+    !$OMP cos_1, cos_2, cos_3, mu, sigma, o, ksi3, &
+    !$OMP p, q, s, z) COLLAPSE(1) SCHEDULE(dynamic)
     do i = 1, natoms
         do j = 1, natoms - 1
             if (i .eq. j) cycle
@@ -832,25 +835,22 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
                 ! The highest of the element indices for atoms j and k
                 q = max(n,m) - 1
                 ! calculate the indices that the three body terms should be added to
-                s = nelements * nbasis2 + nbasis3 * nabasis * (-(p * (p + 1))/2 + q + nelements * p) + 1
+                s = two_body_rep_size + nbasis3 * nabasis * (-(p * (p + 1))/2 + q + nelements * p) + 1
 
                 do l = 1, nbasis3
                     ! calculate the indices that the three body terms should be added to
                     z = s + (l-1) * nabasis
                     ! Add the contributions from atoms i,j and k
-                    rep3(i, z:z + nabasis - 1) = rep3(i, z:z + nabasis - 1) + angular * radial(l) * ksi3
+                    rep(i, z:z + nabasis - 1) = rep(i, z:z + nabasis - 1) + angular * radial(l) * ksi3
                 enddo
             enddo
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
-
-    rep = rep + rep3
+    !$OMP END PARALLEL DO
 
     deallocate(element_types)
     deallocate(rdecay)
     deallocate(distance_matrix)
-    deallocate(rep3)
     deallocate(a)
     deallocate(b)
     deallocate(c)
@@ -860,8 +860,8 @@ subroutine fgenerate_fchl_acsf(coordinates, nuclear_charges, elements, &
 end subroutine fgenerate_fchl_acsf
 
 subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, elements, &
-                    & Rs2, Rs3, Ts, eta2, eta3, zeta, rcut, acut, natoms, rep_size, &
-                    & two_body_decay, three_body_decay, three_body_weight, rep, grad)
+    & Rs2, Rs3, Ts, eta2, eta3, zeta, rcut, acut, natoms, natoms_tot, rep_size, &
+    & two_body_decay, three_body_decay, three_body_weight, rep, grad)
 
     use acsf_utils, only: decay, calc_angle, calc_cos_angle
 
@@ -888,10 +888,14 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     double precision, allocatable, dimension(:) :: exp_ln
     double precision, allocatable, dimension(:) :: log_Rs2
 
-    integer, intent(in) :: natoms
+    integer, intent(in) :: natoms, natoms_tot ! natoms_tot includes "virtual" atoms created to satisfy periodic boundary conditions.
     integer, intent(in) :: rep_size
     double precision, intent(out), dimension(natoms, rep_size) :: rep
     double precision, intent(out), dimension(natoms, rep_size, natoms, 3) :: grad
+
+!   Introduced to make OpenMP parallelization easier.
+    double precision, dimension(:, :, :), allocatable:: add_rep
+    double precision, dimension(:, :, :, :), allocatable :: add_grad
 
     integer :: i, j, k, l, m, n,  p, q, s, t, z, nelements, nbasis2, nbasis3, nabasis, twobody_size
     integer, allocatable, dimension(:) :: element_types
@@ -920,45 +924,44 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     if (natoms /= size(nuclear_charges, dim=1)) then
         write(*,*) "ERROR: Atom Centered Symmetry Functions creation"
         write(*,*) natoms, "coordinates, but", &
-            & size(nuclear_charges, dim=1), "atom_types!"
+        & size(nuclear_charges, dim=1), "atom_types!"
         stop
     endif
-
 
     ! Number of unique elements
     nelements = size(elements)
     ! Allocate temporary
-    allocate(element_types(natoms))
+    allocate(element_types(natoms_tot))
 
     ! Store element index of every atom
-    ! !$OMP PARALLEL DO
-    do i = 1, natoms
+    !$OMP PARALLEL DO SCHEDULE(dynamic)
+    do i = 1, natoms_tot
         do j = 1, nelements
-            if (nuclear_charges(i) .eq. elements(j)) then
+            if (nuclear_charges(modulo(i-1, natoms)+1) .eq. elements(j)) then
                 element_types(i) = j
-                continue
+                exit
             endif
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
 
 
 
     ! Get distance matrix
     ! Allocate temporary
-    allocate(distance_matrix(natoms, natoms))
-    allocate(sq_distance_matrix(natoms, natoms))
-    allocate(inv_distance_matrix(natoms, natoms))
-    allocate(inv_sq_distance_matrix(natoms, natoms))
+    allocate(distance_matrix(natoms_tot, natoms_tot))
+    allocate(sq_distance_matrix(natoms_tot, natoms_tot))
+    allocate(inv_distance_matrix(natoms_tot, natoms_tot))
+    allocate(inv_sq_distance_matrix(natoms_tot, natoms_tot))
     distance_matrix = 0.0d0
     sq_distance_matrix = 0.0d0
     inv_distance_matrix = 0.0d0
     inv_sq_distance_matrix = 0.0d0
 
 
-    ! !$OMP PARALLEL DO PRIVATE(rij,rij2,invrij,invrij2) SCHEDULE(dynamic)
-    do i = 1, natoms
-        do j = i+1, natoms
+    !$OMP PARALLEL DO PRIVATE(rij,rij2,invrij,invrij2) COLLAPSE(1)
+    do i = 1, natoms_tot
+        do j = i+1, natoms_tot
             rij = norm2(coordinates(j,:) - coordinates(i,:))
             distance_matrix(i, j) = rij
             distance_matrix(j, i) = rij
@@ -973,7 +976,7 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
             inv_sq_distance_matrix(j, i) = invrij2
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
 
 
     ! Number of two body basis functions
@@ -982,7 +985,7 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     ! Inverse of the two body cutoff distance
     invcut = 1.0d0 / rcut
     ! Pre-calculate the two body decay
-    rdecay = decay(distance_matrix, invcut, natoms)
+    rdecay = decay(distance_matrix, invcut, natoms_tot)
 
     ! Allocate temporary
     allocate(radial_base(nbasis2))
@@ -995,21 +998,23 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     grad =0.0d0
     rep = 0.0d0
 
+    allocate(add_rep(nbasis2, natoms, natoms), add_grad(nbasis2, 3, natoms, natoms))
+    add_rep=0.0d0
+    add_grad=0.0d0
     log_Rs2(:) = log(Rs2(:))
 
-    ! !$OMP PARALLEL DO PRIVATE(m,n,rij,invrij,radial_base,radial,radial_part,part) REDUCTION(+:rep,grad) &
-    ! !$OMP SCHEDULE(dynamic)
+    !$OMP PARALLEL DO PRIVATE(m, n, rij, invrij, mu, sigma, exp_s2, exp_ln,&
+    !$OMP scaling, radial_base, radial, dx, part, dscal, ddecay) COLLAPSE(1) SCHEDULE(dynamic)
     do i = 1, natoms
-        ! The element index of atom i
-        m = element_types(i)
-        do j = i + 1, natoms
+        do j = i + 1, natoms_tot
+            ! The element index of atom i
+            m = element_types(i) ! moved inside j loop to allow COLLAPSE
             ! The element index of atom j
             n = element_types(j)
             ! Distance between atoms i and j
             rij = distance_matrix(i,j)
             if (rij <= rcut) then
                 invrij = inv_distance_matrix(i,j)
-
                 mu    = log(rij / sqrt(1.0d0 + eta2  * inv_sq_distance_matrix(i, j)))
                 sigma = sqrt(log(1.0d0 + eta2  * inv_sq_distance_matrix(i, j)))
                 exp_s2 = exp(sigma**2)
@@ -1023,35 +1028,47 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
                 radial(:) = radial_base(:) * scaling * rdecay(i,j)
 
                 rep(i, (n-1)*nbasis2 + 1:n*nbasis2) = rep(i, (n-1)*nbasis2 + 1:n*nbasis2) + radial
-                rep(j, (m-1)*nbasis2 + 1:m*nbasis2) = rep(j, (m-1)*nbasis2 + 1:m*nbasis2) + radial
-
-
+                if (j<=natoms) add_rep(:, i, j)=radial
                 do k = 1, 3
-
                     dx = -(coordinates(i,k) - coordinates(j,k))
-
                     part(:) = ((log_Rs2(:) - mu) * (-dx *(rij**2 * exp_s2 + eta2) / (rij * sqrt(exp_s2))**3) &
-                        &* sqrt(exp_s2) / (sigma**2 * rij) + (log_Rs2(:) - mu) ** 2 * eta2 * dx / &
-                        &(sigma**4 * rij**4 * exp_s2)) * exp_ln / (Rs2(:) * sigma  * sqrt(pi) * 2) &
-                        &- exp_ln  * eta2 * dx / (Rs2(:) * sigma**3 *sqrt(pi) * rij**4 * exp_s2 * 2.0d0)
+                                &* sqrt(exp_s2) / (sigma**2 * rij) + (log_Rs2(:) - mu) ** 2 * eta2 * dx / &
+                                &(sigma**4 * rij**4 * exp_s2)) * exp_ln / (Rs2(:) * sigma  * sqrt(pi) * 2) &
+                                &- exp_ln  * eta2 * dx / (Rs2(:) * sigma**3 *sqrt(pi) * rij**4 * exp_s2 * 2.0d0)
 
                     dscal = two_body_decay * dx / rij**(two_body_decay+2.0d0)
                     ddecay = dx * 0.5d0 * pi * sin(pi*rij * invcut) * invcut * invrij
 
                     part(:) = part(:) * scaling * rdecay(i,j) + radial_base(:) * dscal * rdecay(i,j) &
-                        & + radial_base(:) * scaling * ddecay
+                                    & + radial_base(:) * scaling * ddecay
 
                     ! The gradients wrt coordinates
                     grad(i, (n-1)*nbasis2 + 1:n*nbasis2, i, k) = grad(i, (n-1)*nbasis2 + 1:n*nbasis2, i, k) + part
-                    grad(i, (n-1)*nbasis2 + 1:n*nbasis2, j, k) = grad(i, (n-1)*nbasis2 + 1:n*nbasis2, j, k) - part
-                    grad(j, (m-1)*nbasis2 + 1:m*nbasis2, j, k) = grad(j, (m-1)*nbasis2 + 1:m*nbasis2, j, k) - part
-                    grad(j, (m-1)*nbasis2 + 1:m*nbasis2, i, k) = grad(j, (m-1)*nbasis2 + 1:m*nbasis2, i, k) + part
-
+                    if (j<=natoms) then
+                        grad(i, (n-1)*nbasis2 + 1:n*nbasis2, j, k) = grad(i, (n-1)*nbasis2 + 1:n*nbasis2, j, k) - part
+                        grad(j, (m-1)*nbasis2 + 1:m*nbasis2, i, k) = grad(j, (m-1)*nbasis2 + 1:m*nbasis2, i, k) + part
+                        add_grad(:, k, i, j)=part
+                    endif
                 enddo
             endif
         enddo
     enddo
-    ! !$OMP END PARALLEL DO
+    !$OMP END PARALLEL DO
+
+    !$OMP PARALLEL DO PRIVATE(m) SCHEDULE(dynamic)
+    do j = 2, natoms
+        do i = 1, j-1
+            m = element_types(i)
+            if (distance_matrix(i,j)>rcut) continue
+            rep(j, (m-1)*nbasis2 + 1:m*nbasis2) = rep(j, (m-1)*nbasis2 + 1:m*nbasis2) + add_rep(:, i, j)
+            do k=1, 3
+                grad(j, (m-1)*nbasis2 + 1:m*nbasis2, j, k) = grad(j, (m-1)*nbasis2 + 1:m*nbasis2, j, k) - add_grad(:, k, i, j)
+            enddo
+        enddo
+    enddo
+    !$OMP END PARALLEL DO
+
+    deallocate(add_rep, add_grad)
 
     deallocate(radial_base)
     deallocate(radial)
@@ -1069,7 +1086,7 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     ! Inverse of the three body cutoff distance
     invcut = 1.0d0 / acut
     ! Pre-calculate the three body decay
-    rdecay = decay(distance_matrix, invcut, natoms)
+    rdecay = decay(distance_matrix, invcut, natoms_tot)
 
     ! Allocate temporary
     allocate(atom_rep(rep_size - twobody_size))
@@ -1114,17 +1131,17 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
     allocate(d_atm_extra_j(3))
     allocate(d_atm_extra_k(3))
 
-    ! ! This could probably be done more efficiently if it's a bottleneck
-    ! ! The order is a bit wobbly compared to the tensorflow implementation
-    ! !$OMP PARALLEL DO PRIVATE(atom_rep,atom_grad,a,b,c,radial,angular_base, &
-    ! !$OMP angular,d_angular,rij,n,rij2,invrij,invrij2,d_angular_d_i, &
-    ! !$OMP d_angular_d_j,d_angular_d_k,rik,m,rik2,invrik,invrik2,angle, &
-    ! !$OMP p,q,dot,d_radial,d_radial_d_i,d_radial_d_j,d_radial_d_k,s,z, &
-    ! !$OMP d_ijdecay,d_ikdecay) SCHEDULE(dynamic)
+    !$OMP PARALLEL DO PRIVATE(atom_rep, atom_grad, rij, n, rij2, invrij, invrij2,&
+    !$OMP rik, m, rik2, invrik, invrjk, invrik2, a, b, c, angle, cos_i, cos_k,&
+    !$OMP cos_j, radial_base, radial, p, q, dot, angular, d_angular, d_angular_d_j,&
+    !$OMP d_angular_d_k, d_angular_d_i, d_radial, d_radial_d_j, d_radial_d_k,&
+    !$OMP d_radial_d_i, d_ijdecay, d_ikdecay, invr_atm, atm, atm_i, atm_j, atm_k, vi,&
+    !$OMP vj, vk, d_atm_ii, d_atm_ij, d_atm_ik, d_atm_ji, d_atm_jj, d_atm_jk, d_atm_ki,&
+    !$OMP d_atm_kj, d_atm_kk, d_atm_extra_i, d_atm_extra_j, d_atm_extra_k, s, z) SCHEDULE(dynamic)
     do i = 1, natoms
         atom_rep = 0.0d0
         atom_grad = 0.0d0
-        do j = 1, natoms - 1
+        do j = 1, natoms_tot - 1
             if (i .eq. j) cycle
             ! distance between atom i and j
             rij = distance_matrix(i,j)
@@ -1137,7 +1154,7 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
             invrij = inv_distance_matrix(i,j)
             ! inverse squared distance between atom i and j
             invrij2 = inv_sq_distance_matrix(i,j)
-            do k = j + 1, natoms
+            do k = j + 1, natoms_tot
                 if (i .eq. k) cycle
                 ! distance between atom i and k
                 rik = distance_matrix(i,k)
@@ -1250,8 +1267,8 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
                             & angular * radial(l) * (atm_i * d_atm_ii(t) + atm_j * d_atm_ij(t) &
                             & + atm_k * d_atm_ik(t) + d_atm_extra_i(t)) * three_body_weight * rdecay(i,j) * rdecay(i,k) + &
                             & angular * radial(l) * (d_ijdecay(t) * rdecay(i,k) + rdecay(i,j) * d_ikdecay(t)) * atm
-
                         ! Add up all gradient contributions wrt atom j
+                        if (j<=natoms) &
                         atom_grad(z:z + nabasis - 1, j, t) = atom_grad(z:z + nabasis - 1, j, t) + &
                             & d_angular * d_angular_d_j(t) * radial(l) * atm * rdecay(i,j) * rdecay(i,k) + &
                             & angular * d_radial(l) * d_radial_d_j(t) * atm * rdecay(i,j) * rdecay(i,k) + &
@@ -1260,6 +1277,7 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
                             & angular * radial(l) * d_ijdecay(t) * rdecay(i,k) * atm
 
                         ! Add up all gradient contributions wrt atom k
+                        if (k<=natoms) &
                         atom_grad(z:z + nabasis - 1, k, t) = atom_grad(z:z + nabasis - 1, k, t) + &
                             & d_angular * d_angular_d_k(t) * radial(l) * atm * rdecay(i,j) * rdecay(i,k) + &
                             & angular * d_radial(l) * d_radial_d_k(t) * atm * rdecay(i,j) * rdecay(i,k) + &
@@ -1273,33 +1291,33 @@ subroutine fgenerate_fchl_acsf_and_gradients(coordinates, nuclear_charges, eleme
         enddo
         rep(i, twobody_size + 1:) = rep(i, twobody_size + 1:) + atom_rep
         grad(i, twobody_size + 1:,:,:) = grad(i, twobody_size + 1:,:,:) + atom_grad
-    enddo
-    ! !$OMP END PARALLEL DO
+enddo
+!$OMP END PARALLEL DO
 
-    deallocate(rdecay)
-    deallocate(element_types)
-    deallocate(distance_matrix)
-    deallocate(inv_distance_matrix)
-    deallocate(sq_distance_matrix)
-    deallocate(inv_sq_distance_matrix)
-    deallocate(atom_rep)
-    deallocate(atom_grad)
-    deallocate(a)
-    deallocate(b)
-    deallocate(c)
-    deallocate(radial)
-    deallocate(angular_base)
-    deallocate(angular)
-    deallocate(d_angular)
-    deallocate(d_angular_d_i)
-    deallocate(d_angular_d_j)
-    deallocate(d_angular_d_k)
-    deallocate(d_radial)
-    deallocate(d_radial_d_i)
-    deallocate(d_radial_d_j)
-    deallocate(d_radial_d_k)
-    deallocate(d_ijdecay)
-    deallocate(d_ikdecay)
+deallocate(rdecay)
+deallocate(element_types)
+deallocate(distance_matrix)
+deallocate(inv_distance_matrix)
+deallocate(sq_distance_matrix)
+deallocate(inv_sq_distance_matrix)
+deallocate(atom_rep)
+deallocate(atom_grad)
+deallocate(a)
+deallocate(b)
+deallocate(c)
+deallocate(radial)
+deallocate(angular_base)
+deallocate(angular)
+deallocate(d_angular)
+deallocate(d_angular_d_i)
+deallocate(d_angular_d_j)
+deallocate(d_angular_d_k)
+deallocate(d_radial)
+deallocate(d_radial_d_i)
+deallocate(d_radial_d_j)
+deallocate(d_radial_d_k)
+deallocate(d_ijdecay)
+deallocate(d_ikdecay)
 
 
 end subroutine fgenerate_fchl_acsf_and_gradients

--- a/src/qmllib/representations/representations.py
+++ b/src/qmllib/representations/representations.py
@@ -814,13 +814,14 @@ def generate_fchl_acsf(
         for i in range(-nExtend[0], nExtend[0] + 1):
             for j in range(-nExtend[1], nExtend[1] + 1):
                 for k in range(-nExtend[2], nExtend[2] + 1):
-                    if not (i == 0 and j == 0 and k == 0):
-                        true_coords = np.append(
-                            true_coords,
-                            coordinates + i * cell[0, :] + j * cell[1, :] + k * cell[2, :],
-                            axis=0,
-                        )
-                        natoms_tot += natoms
+                    if i == 0 and j == 0 and k == 0:
+                        continue
+                    true_coords = np.append(
+                        true_coords,
+                        coordinates + i * cell[0, :] + j * cell[1, :] + k * cell[2, :],
+                        axis=0,
+                    )
+                    natoms_tot += natoms
         coordinates = true_coords
 
     if gradients is False:

--- a/tests/verification_fchl_acsf_pbc.py
+++ b/tests/verification_fchl_acsf_pbc.py
@@ -16,6 +16,7 @@ np.set_printoptions(linewidth=666, edgeitems=10)
 REP_PARAMS = dict()
 REP_PARAMS["elements"] = [1, 6, 7, 8, 16]
 REP_PARAMS["rcut"] = 5.0
+REP_PARAMS["acut"] = 5.0
 random.seed(1)
 cell_added_cutoff = 0.1
 
@@ -38,7 +39,9 @@ def generate_fchl_acsf_brute_pbc(nuclear_charges, coordinates, cell, gradients=F
     num_atoms = len(nuclear_charges)
     all_coords = deepcopy(coordinates)
     all_charges = deepcopy(nuclear_charges)
-    nExtend = (np.floor(REP_PARAMS["rcut"] / np.linalg.norm(cell, 2, axis=0)) + 1).astype(int)
+    nExtend = (
+        np.floor(max(REP_PARAMS["rcut"], REP_PARAMS["acut"]) / np.linalg.norm(cell, 2, axis=0)) + 1
+    ).astype(int)
     print("Checked nExtend:", nExtend, ", gradient calculation:", gradients)
     for i in range(-nExtend[0], nExtend[0] + 1):
         for j in range(-nExtend[1], nExtend[1] + 1):
@@ -72,7 +75,7 @@ def test_fchl_acsf_pbc():
     qm7_dir = os.path.dirname(os.path.realpath(__file__)) + "/assets/qm7"
     os.chdir(qm7_dir)
     all_xyzs = os.listdir()
-    test_xyzs = random.sample(all_xyzs, 3)
+    test_xyzs = random.sample(all_xyzs, 10)
 
     reps_no_grad1 = []
     reps_no_grad2 = []

--- a/tests/verification_fchl_acsf_pbc.py
+++ b/tests/verification_fchl_acsf_pbc.py
@@ -1,0 +1,125 @@
+"""
+Runs the same calculation using the 'cell' keyword for generate_fchl_acsf and by straightforward
+'cell cloning' done inside the test script.
+"""
+import os
+import random
+from copy import deepcopy
+
+import numpy as np
+
+from qmllib.representations import generate_fchl_acsf
+from qmllib.utils.xyz_format import read_xyz
+
+np.set_printoptions(linewidth=666, edgeitems=10)
+
+REP_PARAMS = dict()
+REP_PARAMS["elements"] = [1, 6, 7, 8, 16]
+REP_PARAMS["rcut"] = 5.0
+random.seed(1)
+cell_added_cutoff = 0.1
+
+
+#   For given molecular coordinates generate a cell just large enough to contain the molecule.
+def suitable_cell(coords):
+    max_coords = None
+    min_coords = None
+    for atom_coords in coords:
+        if max_coords is None:
+            max_coords = deepcopy(atom_coords)
+            min_coords = deepcopy(atom_coords)
+        else:
+            max_coords = np.maximum(max_coords, atom_coords)
+            min_coords = np.minimum(min_coords, atom_coords)
+    return np.diag((max_coords - min_coords) * (1.0 + cell_added_cutoff))
+
+
+def generate_fchl_acsf_brute_pbc(nuclear_charges, coordinates, cell, gradients=False):
+    num_atoms = len(nuclear_charges)
+    all_coords = deepcopy(coordinates)
+    all_charges = deepcopy(nuclear_charges)
+    nExtend = (np.floor(REP_PARAMS["rcut"] / np.linalg.norm(cell, 2, axis=0)) + 1).astype(int)
+    print("Checked nExtend:", nExtend, ", gradient calculation:", gradients)
+    for i in range(-nExtend[0], nExtend[0] + 1):
+        for j in range(-nExtend[1], nExtend[1] + 1):
+            for k in range(-nExtend[2], nExtend[2] + 1):
+                if not (i == 0 and j == 0 and k == 0):
+                    all_coords = np.append(
+                        all_coords,
+                        coordinates + i * cell[0, :] + j * cell[1, :] + k * cell[2, :],
+                        axis=0,
+                    )
+                    all_charges = np.append(all_charges, nuclear_charges)
+    if gradients:
+        rep, drep = generate_fchl_acsf(all_charges, all_coords, gradients=True, **REP_PARAMS)
+    else:
+        rep = generate_fchl_acsf(all_charges, all_coords, gradients=False, **REP_PARAMS)
+    rep = rep[:num_atoms, :]
+    if gradients:
+        drep = drep[:num_atoms, :, :num_atoms, :]
+        return rep, drep
+    else:
+        return rep
+
+
+def ragged_array_close(arr1, arr2, error_msg):
+    for el1, el2 in zip(arr1, arr2):
+        assert np.allclose(el1, el2), error_msg
+
+
+def test_fchl_acsf_pbc():
+
+    qm7_dir = os.path.dirname(os.path.realpath(__file__)) + "/assets/qm7"
+    os.chdir(qm7_dir)
+    all_xyzs = os.listdir()
+    test_xyzs = random.sample(all_xyzs, 3)
+
+    reps_no_grad1 = []
+    reps_no_grad2 = []
+
+    reps_wgrad1 = []
+    reps_wgrad2 = []
+    dreps1 = []
+    dreps2 = []
+
+    for xyz in test_xyzs:
+        print("Tested xyz:", xyz)
+        coords, atoms = read_xyz(xyz)
+        cell = suitable_cell(coords)
+        reps_no_grad1.append(generate_fchl_acsf_brute_pbc(atoms, coords, cell, gradients=False))
+        reps_no_grad2.append(
+            generate_fchl_acsf(atoms, coords, cell=cell, gradients=False, **REP_PARAMS)
+        )
+
+        rep_wgrad1, drep1 = generate_fchl_acsf_brute_pbc(atoms, coords, cell, gradients=True)
+        rep_wgrad2, drep2 = generate_fchl_acsf(
+            atoms, coords, cell=cell, gradients=True, **REP_PARAMS
+        )
+
+        reps_wgrad1.append(rep_wgrad1)
+        reps_wgrad2.append(rep_wgrad2)
+
+        dreps1.append(drep1)
+        dreps2.append(drep2)
+
+    ragged_array_close(
+        reps_no_grad1,
+        reps_no_grad2,
+        "Error in PBC implementation for generate_fchl_acsf without gradients.",
+    )
+    ragged_array_close(
+        reps_wgrad1,
+        reps_wgrad2,
+        "Error in PBC implementation for generate_fchl_acsf with gradients (representation).",
+    )
+    ragged_array_close(
+        dreps1,
+        dreps2,
+        "Error in PBC implementation for generate_fchl_acsf with gradients (gradient of representation).",
+    )
+    print("Passed")
+
+
+if __name__ == "__main__":
+
+    test_fchl_acsf_pbc()


### PR DESCRIPTION
Adds support for periodic boundary conditions when generating FCHL19 representations. Adds the verification script for checking PBC works correctly (temporarily placed into `tests`).

`facsf.f90` revised to avoid using REDUCTION construct in FCHL19's OpenMP parallelization while minimizing the additional CPU and memory usage compared to a serial implementation. Admittedly, I have doubts about how necessary including "!$OMP CRITICAL" was, but I cannot see a better alternative.

Unfortunately, I had trouble getting `qmllib` to work with OpenMP for some reason, hence correctness of `fascf.f90`'s parallelization was verified by using the same file in [my fork of original `qml`](https://github.com/kvkarandashev/qml).